### PR TITLE
Distinguish between activation failure and attempted reactivation.

### DIFF
--- a/docs/default-backend.rst
+++ b/docs/default-backend.rst
@@ -33,15 +33,15 @@ This backend makes use of the following settings:
     not supplied.
 
 ``INCLUDE_AUTH_URLS``
-    A boolean (either ``True`` or ``False``) indicating whether auth urls 
-    (mapped to ``django.contrib.auth.views``) should be included in the 
+    A boolean (either ``True`` or ``False``) indicating whether auth urls
+    (mapped to ``django.contrib.auth.views``) should be included in the
     ``urlpatterns`` of the application backend.
-    
+
 ``INCLUDE_REGISTER_URL``
-    A boolean (either ``True`` or ``False``) indicating whether the view 
-    for registering accounts should be included in the ``urlpatterns`` 
+    A boolean (either ``True`` or ``False``) indicating whether the view
+    for registering accounts should be included in the ``urlpatterns``
     of the application backend.
-    
+
 ``REGISTRATION_FORM``
     A string dotted path to the desired registration form.
 
@@ -107,15 +107,14 @@ the database, using the following model:
    .. attribute:: activation_key
 
       A 40-character ``CharField``, storing the activation key for the
-      account. Initially, the activation key is the hexdigest of a
-      SHA1 hash; after activation, this is reset to :attr:`ACTIVATED`.
+      account. The activation key is the hexdigest of a SHA1 hash.
 
-   Additionally, one class attribute exists:
+   .. attribute:: activated
 
-   .. attribute:: ACTIVATED
-
-      A constant string used as the value of :attr:`activation_key`
-      for accounts which have been activated.
+      A ``BooleanField``, storing whether or not the the User has activated
+      their account. Storing this independent from ``self.user.is_active``
+      allows accounts to be deactivated and prevent being reactivated without
+      authorization.
 
    And the following methods:
 
@@ -125,7 +124,7 @@ the database, using the following model:
       and returns a boolean (``True`` if expired, ``False``
       otherwise). Uses the following algorithm:
 
-      1. If :attr:`activation_key` is :attr:`ACTIVATED`, the account
+      1. If :attr:`activated` is ``True``, the account
          has already been activated and so the key is considered to
          have expired.
 
@@ -205,10 +204,9 @@ Additionally, :class:`RegistrationProfile` has a custom manager
       Validates ``activation_key`` and, if valid, activates the
       associated account by setting its ``is_active`` field to
       ``True``. To prevent re-activation of accounts, the
-      :attr:`~RegistrationProfile.activation_key` of the
+      :attr:`~RegistrationProfile.activated` of the
       :class:`RegistrationProfile` for the account will be set to
-      :attr:`RegistrationProfile.ACTIVATED` after successful
-      activation.
+      ``True`` after successful activation.
 
       Returns the ``User`` instance representing the account if
       activation is successful, ``False`` otherwise.
@@ -246,7 +244,7 @@ Additionally, :class:`RegistrationProfile` has a custom manager
       returns the new ``User`` object representing the account.
 
       :param new_user: The user instance.
-      :type new_user: ``django.contrib.auth.models.AbstractBaseUser```      
+      :type new_user: ``django.contrib.auth.models.AbstractBaseUser```
       :param user_info: The fields to use for the new account.
       :type user_info: dict
       :param site: An object representing the site on which the

--- a/registration/migrations/0002_registrationprofile_activated.py
+++ b/registration/migrations/0002_registrationprofile_activated.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('registration', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='registrationprofile',
+            name='activated',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/registration/migrations/0003_migrate_activatedstatus.py
+++ b/registration/migrations/0003_migrate_activatedstatus.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def migrate_activated_status(apps, schema_editor):
+    # We can't directly import the RegistrationProfile model
+    # as it may be a different version than this migration expects.
+    RegistrationProfile = apps.get_model('registration', 'RegistrationProfile')
+    # Filter the queryset to only fetch already activated profiles.
+    # Note, we don't use the string constant `ACTIVATED` because we are using
+    # the actual model, not necessarily the Python class which has said attribute.
+    for rp in RegistrationProfile.objects.filter(activation_key='ALREADY_ACTIVATED'):
+        # Note, it's impossible to get the original activation key, so just
+        # leave the ALREADY_ACTIVATED string.
+        rp.activated = True
+        rp.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('registration', '0002_registrationprofile_activated'),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_activated_status)
+    ]

--- a/registration/tests/models.py
+++ b/registration/tests/models.py
@@ -196,7 +196,7 @@ class RegistrationModelTests(TestCase):
         self.failUnless(activated.is_active)
 
         profile = RegistrationProfile.objects.get(user=new_user)
-        self.assertEqual(profile.activation_key, RegistrationProfile.ACTIVATED)
+        self.assertTrue(profile.activated)
 
     def test_expired_activation(self):
         """
@@ -221,8 +221,7 @@ class RegistrationModelTests(TestCase):
         self.failIf(new_user.is_active)
 
         profile = RegistrationProfile.objects.get(user=new_user)
-        self.assertNotEqual(profile.activation_key,
-                            RegistrationProfile.ACTIVATED)
+        self.assertFalse(profile.activated)
 
     def test_activation_invalid_key(self):
         """
@@ -243,8 +242,7 @@ class RegistrationModelTests(TestCase):
         RegistrationProfile.objects.activate_user(profile.activation_key)
 
         profile = RegistrationProfile.objects.get(user=new_user)
-        self.failIf(RegistrationProfile.objects
-                    .activate_user(profile.activation_key))
+        self.assertEqual(RegistrationProfile.objects.activate_user(profile.activation_key), new_user)
 
     def test_activation_nonexistent_key(self):
         """


### PR DESCRIPTION
Add a boolean field , `activated` and corresponding migration
to `RegistrationProfile`. Use this field when the user tries
to activate their account to distinguish between:
- account activation failure due to non-existant activation key
- account activation failure due to an expired activation key
- account activation failure due to the user trying to activate
  more than once

By distinguising between these scenarios, it is possible to
provide the user with better information during account activation.
Specifically, if the user is active and tries to reactivate,
clearly indicate their account is active and able to login.

Update documentation and unit tests to account for additional
model field and activation logic.

Before making a pull request upstream, I'd like to:
- [x] sanity check documentation to ensure I've updated everything to reflect this change
- [x] add a data migration to properly set the new boolean `activated` by inspecting if `activation_key == ALREADY_ACTIVATED`
